### PR TITLE
Refactor to improve JS output, use `Fable.Package.SDK`, relax package requirements

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "4.9.0",
+      "version": "4.7.0",
       "commands": [
         "fable"
       ]

--- a/src/ElmishStore.Example/ElmishStore.Example.fsproj
+++ b/src/ElmishStore.Example/ElmishStore.Example.fsproj
@@ -31,6 +31,7 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="Fable.Elmish.Debugger" Version="4.0.0" />
+      <PackageReference Include="Feliz" Version="2.8.0" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\ElmishStore\ElmishStore.fsproj" />

--- a/src/ElmishStore/ElmishStore.fsproj
+++ b/src/ElmishStore/ElmishStore.fsproj
@@ -1,36 +1,41 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-      <PackageId>Elmish.Store</PackageId>
-      <Description>A library that merges Elmish and React, providing an external store with efficient, selective component rendering capabilities.</Description>
-      <PackageTags>fsharp;fable;react;elmish</PackageTags>
-      <Authors>Łukasz Krzywizna</Authors>
-      <Company>SelectView Data Solutions</Company>
-      <Version>0.1.0</Version>
-      <TargetFramework>net8.0</TargetFramework>
-      <PackageReadmeFile>readme.md</PackageReadmeFile>
-      <RepositoryUrl>https://github.com/SelectViewData/elmish-store</RepositoryUrl>
-      <RepositoryType>git</RepositoryType>
-      <PackageLicenseExpression>MIT</PackageLicenseExpression>
-  </PropertyGroup>
-  <PropertyGroup>
-      <NpmDependencies>
-          <NpmPackage Name="use-sync-external-store" Version="&gt;= 1.0.0 &lt; 2.0.0" ResolutionStrategy="Max" />
-      </NpmDependencies>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="UseSyncExternalStore.fs" />
-    <Compile Include="ElmishStore.fs" />
-    <Compile Include="Hooks.fs" />
-    <Compile Include="Extensions.fs" />
-  </ItemGroup>
-  <ItemGroup>
-      <Content Include="*.fsproj; *.fs" Exclude="**\*.fs.js" PackagePath="fable\" />
-      <Content Include="..\..\readme.md" Pack="true" PackagePath="\"/>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Fable.Elmish" Version="4.1.0" />
-    <PackageReference Include="Feliz" Version="2.7.0" />
-    <PackageReference Include="Feliz.CompilerPlugins" Version="2.2.0" />
-  </ItemGroup>
+    <PropertyGroup>
+        <PackageId>Elmish.Store</PackageId>
+        <Description>A library that merges Elmish and React, providing an external store with efficient, selective component rendering capabilities.</Description>
+        <PackageTags>fsharp;fable;react;elmish</PackageTags>
+        <Authors>Łukasz Krzywizna</Authors>
+        <Company>SelectView Data Solutions</Company>
+        <Version>0.2.1</Version>
+        <TargetFramework>net6.0</TargetFramework>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <RepositoryUrl>https://github.com/SelectViewData/elmish-store</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    </PropertyGroup>
+    <PropertyGroup>
+        <PackageTags>fable-javascript</PackageTags>
+        <FablePackageType>library</FablePackageType>
+    </PropertyGroup>
+    <PropertyGroup>
+        <NpmDependencies>
+            <NpmPackage Name="use-sync-external-store" Version="&gt;= 1.0.0 &lt; 2.0.0" ResolutionStrategy="Max" />
+        </NpmDependencies>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="UseSyncExternalStore.fs" />
+        <Compile Include="ElmishStore.fs" />
+        <Compile Include="Hooks.fs" />
+        <Compile Include="Extensions.fs" />
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="..\..\readme.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="6" />
+        <PackageReference Include="Fable.Package.SDK" Version="1.0.0" />
+        <PackageReference Include="Fable.Elmish" Version="4.1.0" />
+        <PackageReference Include="Feliz" Version="2.7.0" />
+        <PackageReference Include="Feliz.CompilerPlugins" Version="2.2.0" />
+    </ItemGroup>
 </Project>

--- a/src/ElmishStore/ElmishStore.fsproj
+++ b/src/ElmishStore/ElmishStore.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="UseSyncExternalStore.fs" />
     <Compile Include="ElmishStore.fs" />
     <Compile Include="Hooks.fs" />
+    <Compile Include="Extensions.fs" />
   </ItemGroup>
   <ItemGroup>
       <Content Include="*.fsproj; *.fs" Exclude="**\*.fs.js" PackagePath="fable\" />

--- a/src/ElmishStore/Extensions.fs
+++ b/src/ElmishStore/Extensions.fs
@@ -1,0 +1,23 @@
+namespace ElmishStore
+
+open Fable.Core
+open Feliz
+open ElmishStore
+
+[<Erase>]
+type React =
+
+    /// Provides a current snapshot of the store's state selected by the selector function.
+    /// NOTE: Selector returning value needs to be referentially stable.
+    static member inline useElmishStore(store, selector: 'model -> 'a) =
+        Hooks.useElmishStore store selector
+
+    /// Provides a current snapshot of the store's state selected by the selector function.
+    /// The result of the selector function is memoized and compared with isEqual function.
+    static member inline useElmishStoreMemoized(store, selector: 'model -> 'a, isEqual) =
+        Hooks.useElmishStoreMemoizedWithCustomEquality store selector isEqual
+
+    /// Provides a current snapshot of the store's state selected by the selector function.
+    /// The result of the selector function is memoized and compared with structural equality.
+    static member inline useElmishStoreMemoized(store, selector: 'model -> 'a) =
+        Hooks.useElmishStoreMemoized store selector

--- a/src/ElmishStore/Hooks.fs
+++ b/src/ElmishStore/Hooks.fs
@@ -1,49 +1,47 @@
-namespace ElmishStore
+module ElmishStore.Hooks
 
 open Fable.Core
 open Feliz
 open ElmishStore
 
-[<Erase>]
-type React =
 
-  /// Provides a current snapshot of the store's state selected by the selector function.
-  /// NOTE: Selector returning value needs to be referentially stable.
-  [<Hook>]
-  static member useElmishStore(store, selector: 'model -> 'a) =
+/// Provides a current snapshot of the store's state selected by the selector function.
+/// NOTE: Selector returning value needs to be referentially stable.
+[<Hook>]
+let useElmishStore store (selector: 'model -> 'a) =
     ReactBindings.useSyncExternalStore (
-      store.Subscribe,
-      React.useCallback (
-        (fun () -> store.GetModel() |> selector),
-        [| box store; box selector |]
-      )
+        store.Subscribe,
+        React.useCallback (
+            (fun () -> store.GetModel() |> selector),
+            [| box store; box selector |]
+        )
     )
 
-  /// Provides a current snapshot of the store's state selected by the selector function.
-  /// The result of the selector function is memoized and compared with isEqual function.
-  [<Hook>]
-  static member useElmishStoreMemoized(store, selector: 'model -> 'a, isEqual) =
+/// Provides a current snapshot of the store's state selected by the selector function.
+/// The result of the selector function is memoized and compared with isEqual function.
+[<Hook>]
+let useElmishStoreMemoizedWithCustomEquality store (selector: 'model -> 'a) isEqual =
     ReactBindings.useSyncExternalStoreWithSelector (
-      store.Subscribe,
-      React.useCallback(
-        (fun () -> store.GetModel()),
-        [| box store; box selector |]
-      ),
-      selector,
-      isEqual
+        store.Subscribe,
+        React.useCallback(
+            (fun () -> store.GetModel()),
+            [| box store; box selector |]
+        ),
+        selector,
+        isEqual
     )
 
-  /// Provides a current snapshot of the store's state selected by the selector function.
-  /// The result of the selector function is memoized and compared with structural equality.
-  [<Hook>]
-  static member useElmishStoreMemoized(store, selector: 'model -> 'a) =
+/// Provides a current snapshot of the store's state selected by the selector function.
+/// The result of the selector function is memoized and compared with structural equality.
+[<Hook>]
+let useElmishStoreMemoized store (selector: 'model -> 'a) =
     ReactBindings.useSyncExternalStoreWithSelector (
-      store.Subscribe,
-      React.useCallback(
-        (fun () -> store.GetModel()),
-        [| box store; box selector |]
-      ),
-      selector,
-      (=)
+        store.Subscribe,
+        React.useCallback(
+            (fun () -> store.GetModel()),
+            [| box store; box selector |]
+        ),
+        selector,
+        (=)
     )
 

--- a/src/ElmishStore/UseSyncExternalStore.fs
+++ b/src/ElmishStore/UseSyncExternalStore.fs
@@ -27,7 +27,6 @@ type internal ReactBindings =
     ) : 'a =
     jsNative
 
-  [<Hook>]
   static member inline useSyncExternalStoreWithSelector
     (
       subscribe: UseSyncExternalStoreSubscribe,


### PR DESCRIPTION
## 1. Refactor hooks to make Fable's JS output cleaner

Hooks defined as static members are prefixed with class name, what makes their names too cluttered. To fix that, I've converted the hooks to module functions. And to preserve the same `React`-type static methods API, the type made Erased and all its methods made just as inline wrappers.

## 2. Use [`Fable.Package.SDK`](https://github.com/fable-compiler/Fable.Package.SDK), relax .NET and `FSharp.Core` requirements.

.NET 8 and `FSharp.Core v8` seems unnecessarily high requirements, so I relaxed them to .NET 6 and `FSharp.Core v6`. 