### PR TITLE
Generalize and extend API

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "4.9.0",
+      "version": "4.7.0",
       "commands": [
         "fable"
       ]

--- a/src/ElmishStore.Example/ElmishStore.Example.fsproj
+++ b/src/ElmishStore.Example/ElmishStore.Example.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>

--- a/src/ElmishStore.Example/ElmishStore.Example.fsproj
+++ b/src/ElmishStore.Example/ElmishStore.Example.fsproj
@@ -31,6 +31,7 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="Fable.Elmish.Debugger" Version="4.0.0" />
+      <PackageReference Include="Feliz" Version="2.8.0" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\ElmishStore\ElmishStore.fsproj" />

--- a/src/ElmishStore.Example/ModelStore.fs
+++ b/src/ElmishStore.Example/ModelStore.fs
@@ -11,13 +11,16 @@ open Elmish.Debug
 
 #endif
 
+let storesHost = ElmishStoresHost<string>()
+
 let store =
-  Program.mkProgram init update (fun _ _ -> ())
-  #if DEBUG
-  |> Program.withConsoleTrace
-  |> Program.withDebugger
-  #endif
-  |> ElmishStore.createStore "main"
+    let program =
+        Program.mkProgram init update (fun _ _ -> ())
+        #if DEBUG
+        |> Program.withConsoleTrace
+        |> Program.withDebugger
+        #endif
+    storesHost.create "main" program
 
 [<Hook>]
 let useSelector (selector: Model -> 'a) = React.useElmishStore (store, selector)

--- a/src/ElmishStore.Example/ModelStore.fs
+++ b/src/ElmishStore.Example/ModelStore.fs
@@ -11,6 +11,8 @@ open Elmish.Debug
 
 #endif
 
+// One additional step (comparing with the previous module-based API).
+// However, creating the Host on the global level is essentially the same as using the module-based API.
 let storesHost = ElmishStoresHost<string>()
 
 let store =
@@ -22,17 +24,21 @@ let store =
         #endif
     storesHost.create "main" program
 
-(*
+(*// Previous API:
 [<Hook>]
 let useSelector (selector: Model -> 'a) = React.useElmishStore (store, selector)
 
 [<Hook>]
 let useSelectorMemoized (memoizedSelector: Model -> 'a) =
-  React.useElmishStoreMemoized (store, memoizedSelector)
+    React.useElmishStoreMemoized (store, memoizedSelector)
 *)
 
-let storeApi = StoreApi.getStoreApi store
+// Instead of defining separate custom hooks for a specific Store,
+// just create all the Store-related hooks packed in an object.
+let storeApi = StoreApi.getElmishStoreApi store
 
+// These helpers should be inline so that Fable doesn't generate unnecessary extra-functions around the hooks.
+// However, these helpers aren't really needed, as the hooks could be called directly from the `storeApi` value.
 let inline useSelector selector = storeApi.useSelector selector
 let inline useSelectorMemoized selector = storeApi.useSelectorMemoized selector
 

--- a/src/ElmishStore.Example/ModelStore.fs
+++ b/src/ElmishStore.Example/ModelStore.fs
@@ -22,11 +22,18 @@ let store =
         #endif
     storesHost.create "main" program
 
+(*
 [<Hook>]
 let useSelector (selector: Model -> 'a) = React.useElmishStore (store, selector)
 
 [<Hook>]
 let useSelectorMemoized (memoizedSelector: Model -> 'a) =
   React.useElmishStoreMemoized (store, memoizedSelector)
+*)
+
+let storeApi = StoreApi.getStoreApi store
+
+let inline useSelector selector = storeApi.useSelector selector
+let inline useSelectorMemoized selector = storeApi.useSelectorMemoized selector
 
 let dispatch = store.Dispatch

--- a/src/ElmishStore/ElmishStore.fsproj
+++ b/src/ElmishStore/ElmishStore.fsproj
@@ -1,36 +1,41 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-      <PackageId>Elmish.Store</PackageId>
-      <Description>A library that merges Elmish and React, providing an external store with efficient, selective component rendering capabilities.</Description>
-      <PackageTags>fsharp;fable;react;elmish</PackageTags>
-      <Authors>Łukasz Krzywizna</Authors>
-      <Company>SelectView Data Solutions</Company>
-      <Version>0.1.0</Version>
-      <TargetFramework>net8.0</TargetFramework>
-      <PackageReadmeFile>readme.md</PackageReadmeFile>
-      <RepositoryUrl>https://github.com/SelectViewData/elmish-store</RepositoryUrl>
-      <RepositoryType>git</RepositoryType>
-      <PackageLicenseExpression>MIT</PackageLicenseExpression>
-  </PropertyGroup>
-  <PropertyGroup>
-      <NpmDependencies>
-          <NpmPackage Name="use-sync-external-store" Version="&gt;= 1.0.0 &lt; 2.0.0" ResolutionStrategy="Max" />
-      </NpmDependencies>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="UseSyncExternalStore.fs" />
-    <Compile Include="ElmishStore.fs" />
-    <Compile Include="Hooks.fs" />
-    <Compile Include="Extensions.fs" />
-  </ItemGroup>
-  <ItemGroup>
-      <Content Include="*.fsproj; *.fs" Exclude="**\*.fs.js" PackagePath="fable\" />
-      <Content Include="..\..\readme.md" Pack="true" PackagePath="\"/>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Fable.Elmish" Version="4.1.0" />
-    <PackageReference Include="Feliz" Version="2.7.0" />
-    <PackageReference Include="Feliz.CompilerPlugins" Version="2.2.0" />
-  </ItemGroup>
+    <PropertyGroup>
+        <PackageId>Elmish.Store</PackageId>
+        <Description>A library that merges Elmish and React, providing an external store with efficient, selective component rendering capabilities.</Description>
+        <PackageTags>fsharp;fable;react;elmish</PackageTags>
+        <Authors>Łukasz Krzywizna</Authors>
+        <Company>SelectView Data Solutions</Company>
+        <Version>0.2.1</Version>
+        <TargetFramework>net6.0</TargetFramework>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <RepositoryUrl>https://github.com/SelectViewData/elmish-store</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    </PropertyGroup>
+    <PropertyGroup>
+        <PackageTags>fable-javascript</PackageTags>
+        <FablePackageType>library</FablePackageType>
+    </PropertyGroup>
+    <PropertyGroup>
+        <NpmDependencies>
+            <NpmPackage Name="use-sync-external-store" Version="&gt;= 1.0.0 &lt; 2.0.0" ResolutionStrategy="Max" />
+        </NpmDependencies>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="UseSyncExternalStore.fs" />
+        <Compile Include="ElmishStore.fs" />
+        <Compile Include="Hooks.fs" />
+        <Compile Include="Extensions.fs" />
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="..\..\readme.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="6" />
+        <PackageReference Include="Fable.Package.SDK" Version="1.0.0" />
+        <PackageReference Include="Fable.Elmish" Version="4.1.0" />
+        <PackageReference Include="Feliz" Version="2.7.0" />
+        <PackageReference Include="Feliz.CompilerPlugins" Version="2.2.0" />
+    </ItemGroup>
 </Project>

--- a/src/ElmishStore/ElmishStore.fsproj
+++ b/src/ElmishStore/ElmishStore.fsproj
@@ -6,7 +6,7 @@
         <PackageTags>fsharp;fable;react;elmish</PackageTags>
         <Authors>Łukasz Krzywizna</Authors>
         <Company>SelectView Data Solutions</Company>
-        <Version>0.2.1</Version>
+        <Version>0.3.0-beta.0</Version>
         <TargetFramework>net6.0</TargetFramework>
         <PackageReadmeFile>readme.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/SelectViewData/elmish-store</RepositoryUrl>

--- a/src/ElmishStore/ElmishStore.fsproj
+++ b/src/ElmishStore/ElmishStore.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="UseSyncExternalStore.fs" />
     <Compile Include="ElmishStore.fs" />
     <Compile Include="Hooks.fs" />
+    <Compile Include="Extensions.fs" />
   </ItemGroup>
   <ItemGroup>
       <Content Include="*.fsproj; *.fs" Exclude="**\*.fs.js" PackagePath="fable\" />

--- a/src/ElmishStore/ElmishStore.fsproj
+++ b/src/ElmishStore/ElmishStore.fsproj
@@ -6,7 +6,7 @@
         <PackageTags>fsharp;fable;react;elmish</PackageTags>
         <Authors>Łukasz Krzywizna</Authors>
         <Company>SelectView Data Solutions</Company>
-        <Version>0.3.0-beta.0</Version>
+        <Version>0.3.0-beta.1</Version>
         <TargetFramework>net6.0</TargetFramework>
         <PackageReadmeFile>readme.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/SelectViewData/elmish-store</RepositoryUrl>
@@ -26,6 +26,7 @@
         <Compile Include="UseSyncExternalStore.fs" />
         <Compile Include="ElmishStore.fs" />
         <Compile Include="Hooks.fs" />
+        <Compile Include="StoreApi.fs" />
         <Compile Include="Extensions.fs" />
     </ItemGroup>
     <ItemGroup>

--- a/src/ElmishStore/Extensions.fs
+++ b/src/ElmishStore/Extensions.fs
@@ -1,0 +1,23 @@
+namespace ElmishStore
+
+open Fable.Core
+open Feliz
+open ElmishStore
+
+[<Erase>]
+type React =
+
+    /// Provides a current snapshot of the store's state selected by the selector function.
+    /// NOTE: Selector returning value needs to be referentially stable.
+    static member inline useElmishStore(store, selector: 'model -> 'a) =
+        Hooks.useElmishStore store selector
+
+    /// Provides a current snapshot of the store's state selected by the selector function.
+    /// The result of the selector function is memoized and compared with isEqual function.
+    static member inline useElmishStoreMemoized(store, selector: 'model -> 'a, isEqual) =
+        Hooks.useElmishStoreMemoizedWithCustomEquality store selector isEqual
+
+    /// Provides a current snapshot of the store's state selected by the selector function.
+    /// The result of the selector function is memoized and compared with structural equality.
+    static member inline useElmishStoreMemoized(store, selector: 'model -> 'a) =
+        Hooks.useElmishStoreMemoized store selector

--- a/src/ElmishStore/Hooks.fs
+++ b/src/ElmishStore/Hooks.fs
@@ -1,49 +1,47 @@
-namespace ElmishStore
+module ElmishStore.Hooks
 
 open Fable.Core
 open Feliz
 open ElmishStore
 
-[<Erase>]
-type React =
 
-  /// Provides a current snapshot of the store's state selected by the selector function.
-  /// NOTE: Selector returning value needs to be referentially stable.
-  [<Hook>]
-  static member useElmishStore(store, selector: 'model -> 'a) =
+/// Provides a current snapshot of the store's state selected by the selector function.
+/// NOTE: Selector returning value needs to be referentially stable.
+[<Hook>]
+let useElmishStore store (selector: 'model -> 'a) =
     ReactBindings.useSyncExternalStore (
-      store.Subscribe,
-      React.useCallback (
-        (fun () -> store.GetModel() |> selector),
-        [| box store; box selector |]
-      )
+        store.Subscribe,
+        React.useCallback (
+            (fun () -> store.GetModel() |> selector),
+            [| box store; box selector |]
+        )
     )
 
-  /// Provides a current snapshot of the store's state selected by the selector function.
-  /// The result of the selector function is memoized and compared with isEqual function.
-  [<Hook>]
-  static member useElmishStoreMemoized(store, selector: 'model -> 'a, isEqual) =
+/// Provides a current snapshot of the store's state selected by the selector function.
+/// The result of the selector function is memoized and compared with isEqual function.
+[<Hook>]
+let useElmishStoreMemoizedWithCustomEquality store (selector: 'model -> 'a) isEqual =
     ReactBindings.useSyncExternalStoreWithSelector (
-      store.Subscribe,
-      React.useCallback(
-        (fun () -> store.GetModel()),
-        [| box store; box selector |]
-      ),
-      selector,
-      isEqual
+        store.Subscribe,
+        React.useCallback(
+            (fun () -> store.GetModel()),
+            [| box store; box selector |]
+        ),
+        selector,
+        isEqual
     )
 
-  /// Provides a current snapshot of the store's state selected by the selector function.
-  /// The result of the selector function is memoized and compared with structural equality.
-  [<Hook>]
-  static member useElmishStoreMemoized(store, selector: 'model -> 'a) =
+/// Provides a current snapshot of the store's state selected by the selector function.
+/// The result of the selector function is memoized and compared with structural equality.
+[<Hook>]
+let useElmishStoreMemoized store (selector: 'model -> 'a) =
     ReactBindings.useSyncExternalStoreWithSelector (
-      store.Subscribe,
-      React.useCallback(
-        (fun () -> store.GetModel()),
-        [| box store; box selector |]
-      ),
-      selector,
-      (=)
+        store.Subscribe,
+        React.useCallback(
+            (fun () -> store.GetModel()),
+            [| box store; box selector |]
+        ),
+        selector,
+        (=)
     )
 

--- a/src/ElmishStore/StoreApi.fs
+++ b/src/ElmishStore/StoreApi.fs
@@ -1,0 +1,44 @@
+module ElmishStore.StoreApi
+
+open Feliz
+
+type IElmishStoreHooks<'Model> =
+    /// Provides a current snapshot of the store's state selected by the selector function.
+    /// NOTE: Selector returning value needs to be referentially stable.
+    abstract useSelector : selector: ('Model -> 'T) -> 'T
+    /// Provides a current snapshot of the store's state selected by the selector function.
+    /// The result of the selector function is memoized and compared with structural equality.
+    abstract useSelectorMemoized<'T when 'T : equality> : selector: ('Model -> 'T) -> 'T
+    /// Provides a current snapshot of the store's state selected by the selector function.
+    /// The result of the selector function is memoized and compared with isEqual function.
+    abstract useSelectorMemoizedWithCustomEquality : selector: ('Model -> 'T) -> isEqual: ('T -> 'T -> bool) -> 'T
+
+type IElmishStoreApi<'Model, 'Msg> =
+    inherit IElmishStoreHooks<'Model>
+
+    abstract Store : ElmishStore<'Model, 'Msg>
+
+
+let getElmishStoreApi (store: ElmishStore<'Model, 'Msg>) =
+    { new IElmishStoreApi<'Model, 'Msg> with
+        member _.Store = store
+
+        member _.useSelector(selector: 'Model -> 'T): 'T = 
+            Hooks.useElmishStore store selector
+
+        member _.useSelectorMemoized<'T when 'T : equality> (selector: 'Model -> 'T) =
+            Hooks.useElmishStoreMemoized store selector
+
+        member _.useSelectorMemoizedWithCustomEquality<'T>
+            (selector: 'Model -> 'T)
+            (isEqual: 'T -> 'T -> bool): 'T
+            =
+            Hooks.useElmishStoreMemoizedWithCustomEquality store selector isEqual
+    }
+
+
+[<Hook>]
+let useElmishStoreApi (store: ElmishStore<'Model, 'Msg>) =
+    React.useMemo (fun () ->
+        getElmishStoreApi store
+    , [| store |])

--- a/src/ElmishStore/UseSyncExternalStore.fs
+++ b/src/ElmishStore/UseSyncExternalStore.fs
@@ -27,7 +27,6 @@ type internal ReactBindings =
     ) : 'a =
     jsNative
 
-  [<Hook>]
   static member inline useSyncExternalStoreWithSelector
     (
       subscribe: UseSyncExternalStoreSubscribe,


### PR DESCRIPTION
> **N.B.** This PR also includes the commits from #3, so if this PR is viable, I suppose It'd be easier to accept it right away, ignoring PR #3.

All these changes essentially just generalize and extend the API, permitting the previous usage as well. The example is also updated to use the new API.

## 1. Introduce `ElmishStoresHost` type with generic store key, as a replacement for `ElmishStore` module

- Replace `ElmishStore` module that statically defines Stores registry, with `ElmishStoresHost` type that incapsulates the registry. This allows manually defining Stores "root" in any place of an application.
For example, it should allow defining store's root inside React context. Technically, this should give possibility to use many Stores with the same key if they're defined inside different Context Providers, where each Context Provider creates a new instance of `ElmishStoresHost`. Don't know if this is a good solution, and maybe it's better to handle this through a single host and different generated Store keys.

- The `uniqueName` string parameter used as store key is replaced with a generically defined `storeKey` parameter. This gives possibility use any type (that fits `equality` constraint) as a store's key, not only `string`. For example, GUID, or a custom DU type value.

## 2. Introduce `StoreApi` module

The module defines `IElmishStoreApi` interface to represent an object that incapsulates the `ElmishStore` itself and a set of selector hooks on the `ElmishStore` instance.
Also, the module provides:
- `getElmishStoreApi` function that returns an object with `IElmishStoreApi` value.
- `useElmishStoreApi` hook that just memoizes `getElmishStoreApi` result.

This API allows to create all the Store instance related hooks at once, instead of defining them one by one manually.